### PR TITLE
Updating to use new base box, confd, s6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Designed to used with:
 
 Based on:
 
-* Official PHP Apache image: [php:7.4.3-apache](https://hub.docker.com/layers/php/library/php/7.4.3-apache/images/sha256-48dde1707d7dca2b701aa230344c58cb8ec5b0ce8e9dbceced65bec5ccd7d1d0?context=explore)
+* [isle-crayfish-base](https://github.com/Islandora-Devops/isle-crayfish-base)
 
 Contains and includes:
 
@@ -15,31 +15,19 @@ Contains and includes:
 * [ffmpeg](https://packages.debian.org/buster/ffmpeg)
 * [Homarus](https://github.com/Islandora/Crayfish/tree/dev/Homarus)
 
-## MVP 2 sprint
-
-### Building
-
-There are two build arguments that you must provide in order to build this container:
-
-* HOMARUS_JWT_ADMIN_TOKEN - An easy to remember token to replace an actual JWT when testing (usually "islandora")
-* HOMARUS_LOG_LEVEL - Logging level for the Homarus microservice (DEBUG, INFO, WARN, ERROR, etc...)
-
-In order to build, run this command
-
-* `docker build -t isle-homarus --build-arg HOMARUS_JWT_ADMIN_TOKEN=islandora --build-arg HOMARUS_LOG_LEVEL=DEBUG .`
-
-Or if you've defined the build args as environment variables already, simply
-
-* `docker build -t isle-homarus --build-arg HOMARUS_JWT_ADMIN_TOKEN --build-arg HOMARUS_LOG_LEVEL .`
-
-### Running
+## Running
 
 To run the container, you'll need to bind mount two things:
 
 * A public key from the key pair used to sign and verify JWT tokens at `/opt/keys/public.key`
 * A `php.ini` file with output buffering enabled at `/usr/local/etc/php/php.ini`
 
-* `docker run -d -p 8000:8000 -v /path/to/public.key:/opt/keys/public.key -v /path/to/php.ini:/usr/local/etc/php/php.ini isle-homarus`
+You'll also want to set two environment variables, which affect configuration of the microservice
+
+* HOMARUS_JWT_ADMIN_TOKEN - An easy to remember token to replace an actual JWT when testing (usually "islandora")
+* HOMARUS_LOG_LEVEL - Logging level for the Homarus microservice (DEBUG, INFO, WARN, ERROR, etc...)
+
+`docker run -d -p 8000:8000 -e HOMARUS_JWT_ADMIN_TOKEN=islandora -e HOMARUS_LOG_LEVEL=DEBUG -v /path/to/public.key:/opt/keys/public.key -v /path/to/php.ini:/usr/local/etc/php/php.ini isle-homarus`
 
 ### Testing
 
@@ -47,4 +35,4 @@ To test Homarus, you can issue a curl command against it to verify its endpoint 
 
 * `curl -H "Authorization: Bearer islandora" -H "Apix-Ldp-Resource: http://techslides.com/demos/sample-videos/small.ogv" -H "Accept: video/mp4" idcp.localhost:8000/convert > converted.mp4`
 
-Note the the `Authorization` header contains the HOUDINI_JWT_ADMIN_TOKEN value after `Bearer`.
+Note the the `Authorization` header contains the HOMARUS_JWT_ADMIN_TOKEN value after `Bearer`.

--- a/rootfs/etc/confd/conf.d/config.toml
+++ b/rootfs/etc/confd/conf.d/config.toml
@@ -1,0 +1,7 @@
+[template]
+src = "config.yaml.tpl"
+dest = "/opt/crayfish/Homarus/cfg/config.yaml"
+mode = "0644"
+keys = [
+    "/homarus/log/level",
+]

--- a/rootfs/etc/confd/conf.d/syn-settings.toml
+++ b/rootfs/etc/confd/conf.d/syn-settings.toml
@@ -1,0 +1,7 @@
+[template]
+src = "syn-settings.xml.tpl"
+dest = "/opt/crayfish/Homarus/syn-settings.xml"
+mode = "0644"
+keys = [
+    "/homarus/jwt/admin/token",
+]

--- a/rootfs/etc/confd/templates/config.yaml.tpl
+++ b/rootfs/etc/confd/templates/config.yaml.tpl
@@ -30,7 +30,7 @@ log:
   # Valid log levels are:
   # DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY, NONE
   # log level none won't open logfile
-  level: $HOMARUS_LOG_LEVEL
+  level: {{getv "/homarus/log/level"}}
   file: /var/log/islandora/homarus.log
 
 syn:

--- a/rootfs/etc/confd/templates/syn-settings.xml.tpl
+++ b/rootfs/etc/confd/templates/syn-settings.xml.tpl
@@ -3,6 +3,6 @@
 <config version='1'>
     <site algorithm='RS256' encoding='PEM' path='/opt/jwt/public.key' default='true' anonymous='true'/>
     <token user='admin' roles='admin'>
-        $HOMARUS_JWT_ADMIN_TOKEN
+        {{getv "/homarus/jwt/admin/token"}}
     </token>
 </config>


### PR DESCRIPTION
## Testing

I tested this by following the README. I built with
`docker build -t isle-homarus .`

and then ran it with this (note I bind mounted in some files from isle-dc)
`docker run -d -p 8000:8000 -e HOMARUS_JWT_ADMIN_TOKEN=islandora -e HOMARUS_LOG_LEVEL=DEBUG -v ~/Code/Environments/isle-dc/config/jwt/public.key:/opt/keys/public.key -v ~/Code/Environments/isle-dc/config/crayfish/php.ini:/usr/local/etc/php/php.ini isle-homarus`

Then I ran ffmpeg on to convert an ogv to mp4:
`curl -H "Authorization: Bearer islandora" -H "Apix-Ldp-Resource: http://techslides.com/demos/sample-videos/small.ogv" -H "Accept: video/mp4" idcp.localhost:8000/convert > converted.mp4`